### PR TITLE
Fix undefined GOPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GOPATH ?= ${shell go env GOPATH}
+
+
 all:
 	@cd $(GOPATH)/src; go install github.com/Symantec/cloud-gate/cmd/*
 


### PR DESCRIPTION
Makefile assumed GOPATH is defined in user environment, which is not
the case by default. With GOPATH undefined `make all` target would
attempt to cd into `/src` and run `go install` command there, which,
of course, fails.

This change adds GOPATH env var definition to Makefile which fetches the
value from `go env`.