### PR TITLE
Improve cloud-gate cmd

### DIFF
--- a/cmd/cloud-gate/main.go
+++ b/cmd/cloud-gate/main.go
@@ -24,15 +24,15 @@ var (
 )
 
 func main() {
-	flag.Parse()
-	tricorder.RegisterFlags()
 	if os.Geteuid() == 0 {
 		fmt.Fprintln(os.Stderr, "Do not run the cloud-gate server as root")
 		os.Exit(1)
 	}
+	flag.Parse()
+	tricorder.RegisterFlags()
 	logger := serverlogger.New("")
-	configChannel, err := configuration.Watch(*configurationUrl,
-		*configurationCheckInterval, logger)
+	configChannel, err := configuration.Watch(
+		*configurationUrl, *configurationCheckInterval, logger)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Cannot watch for configuration:", err)
 		os.Exit(1)

--- a/cmd/cloud-gate/main.go
+++ b/cmd/cloud-gate/main.go
@@ -34,15 +34,20 @@ func main() {
 	configChannel, err := configuration.Watch(*configurationUrl,
 		*configurationCheckInterval, logger)
 	if err != nil {
-		logger.Fatalf("Cannot watch for configuration: %s\n", err)
+		fmt.Fprintln(os.Stderr, "Cannot watch for configuration:", err)
+		os.Exit(1)
 	}
 	brokers := map[string]broker.Broker{
 		"aws": aws.New(logger),
 	}
 	webServer, err := httpd.StartServer(*portNum, brokers, logger)
 	if err != nil {
-		logger.Fatalf("Unable to create http server: %s\n", err)
+		fmt.Fprintln(os.Stderr, "Unable to create HTTP server:", err)
+		os.Exit(1)
+	} else {
+		fmt.Printf("HTTP server started, status page at http://localhost:%d/status\n", *portNum)
 	}
+
 	webServer.AddHtmlWriter(logger)
 	for config := range configChannel {
 		logger.Println("Received new configuration")

--- a/cmd/cloud-gate/main.go
+++ b/cmd/cloud-gate/main.go
@@ -19,7 +19,7 @@ var (
 		time.Minute*5, "Configuration check interval")
 	configurationUrl = flag.String("configurationUrl",
 		"file:///etc/cloud-gate/conf.yml", "URL containing configuration")
-	portNum = flag.Uint("portNum", 443,
+	portNum = flag.Uint("portNum", 4443,
 		"Port number to allocate and listen on for HTTP/RPC")
 )
 


### PR DESCRIPTION
Changes
-------

c312eb1 (Ruslan Kiyanchuk, 9 minutes ago)
   Make check for running as root the first action

   Since cloud-gate exits immediately if user tries to run it as root, there
   is no need to do any flags parcing, etc prior to "running as root" check.

fc541d6 (Ruslan Kiyanchuk, 12 minutes ago)
   Fix error printing before HTTP server started

   Errors occuring before HTTP server is started are still sent to
   `serverlogger` which makes them invisible.

   These errors are now printed to Stderr instead. Once the HTTP server is
   started, cloud-gate hints the user where to look for further logs.

dddc527 (Ruslan Kiyanchuk, 14 minutes ago)
   Switch to unprivileged default port

   Considering that cloud-gate prevents the user to run it as root and exits
   immediately in such case, default value 443 for `portNum` config parameter
   is useless.

   Switching default port value to 4443 allows cloud-gate to operate normally
   without additional CLI flags passed.